### PR TITLE
docs: Add TicketSource importer documentation

### DIFF
--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -14,6 +14,7 @@ By default PlaceCal supports [iCal/.ics](ical-generic.md) and [JSON-LD](json-ld-
 * [OutSavvy](outsavvy.md)
 * [Resident Advisor](resident-advisor-ra.md) (RA)
 * [Squarespace](squarespace.md)
+* [TicketSource](ticketsource.md)
 * [Ticketsolve](ticketsolve.md)
 
 ## Sources PlaceCal doesn't support

--- a/docs/reference/supported-calendar-sources/ticketsource.md
+++ b/docs/reference/supported-calendar-sources/ticketsource.md
@@ -13,7 +13,7 @@ You need two things to set up a TicketSource calendar in PlaceCal:
    2. Go to **Settings** > **API**
    3. Copy your API key using the copy button next to it
 
-   See [TicketSource's API integration guide](https://help.ticketsource.com/en/article/api-integration-10o5gun/) for more details.
+   Your API key will look something like `skl-1a2b3c4d5e6f7a8b9c0d`. See [TicketSource's API integration guide](https://help.ticketsource.com/en/article/api-integration-10o5gun/) for more details.
 
 Paste the venue URL into the URL field and the API key into the API key field when [adding a calendar](../../how-to/add-a-calendar.md). PlaceCal will automatically detect it as a TicketSource source and import all upcoming events from that venue.
 

--- a/docs/reference/supported-calendar-sources/ticketsource.md
+++ b/docs/reference/supported-calendar-sources/ticketsource.md
@@ -8,7 +8,12 @@ You need two things to set up a TicketSource calendar in PlaceCal:
 
 1. **Your venue page URL** (not individual event pages), in the format:
    * `https://www.ticketsource.co.uk/your-venue-name`
-2. **A TicketSource API key**. You can find this in your TicketSource account settings under API Keys.
+2. **A TicketSource API key**. To find this:
+   1. Log in to your [TicketSource](https://www.ticketsource.co.uk/) account
+   2. Go to **Settings** > **API**
+   3. Copy your API key using the copy button next to it
+
+   See [TicketSource's API integration guide](https://help.ticketsource.com/en/article/api-integration-10o5gun/) for more details.
 
 Paste the venue URL into the URL field and the API key into the API key field when [adding a calendar](../../how-to/add-a-calendar.md). PlaceCal will automatically detect it as a TicketSource source and import all upcoming events from that venue.
 

--- a/docs/reference/supported-calendar-sources/ticketsource.md
+++ b/docs/reference/supported-calendar-sources/ticketsource.md
@@ -1,20 +1,18 @@
 # TicketSource
 
-> 🥉 **Bronze Integration** - This is a [fragile integration](README.md#-bronze---fragile) that scrapes data from web pages. It may break if TicketSource changes their website structure.
-
-PlaceCal can import events from TicketSource venue pages. TicketSource is a UK-based ticketing platform used by many theatres, arts centres, and community venues.
+PlaceCal can import events from TicketSource using their REST API. TicketSource is a UK-based ticketing platform used by many theatres, arts centres, and community venues.
 
 ## How to import from TicketSource
 
-To import events from TicketSource, you need the URL of your **venue page** (not individual event pages). This is typically in the format:
+You need two things to set up a TicketSource calendar in PlaceCal:
 
-* `https://www.ticketsource.co.uk/your-venue-name`
+1. **Your venue page URL** (not individual event pages), in the format:
+   * `https://www.ticketsource.co.uk/your-venue-name`
+2. **A TicketSource API key**. You can find this in your TicketSource account settings under API Keys.
 
-Simply paste this URL into the calendar field when [adding a calendar](../../how-to/add-a-calendar.md). PlaceCal will automatically detect it as a TicketSource source and import all upcoming events from that venue.
+Paste the venue URL into the URL field and the API key into the API key field when [adding a calendar](../../how-to/add-a-calendar.md). PlaceCal will automatically detect it as a TicketSource source and import all upcoming events from that venue.
 
 ## Information PlaceCal imports from TicketSource
-
-PlaceCal pulls the following from TicketSource events:
 
 * Event title
 * Description

--- a/docs/reference/supported-calendar-sources/ticketsource.md
+++ b/docs/reference/supported-calendar-sources/ticketsource.md
@@ -1,5 +1,7 @@
 # TicketSource
 
+> 🥉 **Bronze Integration** - This is a [fragile integration](README.md#-bronze---fragile) that scrapes data from web pages. It may break if TicketSource changes their website structure.
+
 PlaceCal can import events from TicketSource venue pages. TicketSource is a UK-based ticketing platform used by many theatres, arts centres, and community venues.
 
 ## How to import from TicketSource
@@ -30,10 +32,3 @@ PlaceCal imports from venue pages, not individual event pages. Make sure you use
 ### Multiple time slots
 
 If an event has multiple performances or time slots, PlaceCal will import each one as a separate event with its own date and time.
-
-### Fragile importer
-
-Like other web-scraping importers, TicketSource does not provide a public API or feed. PlaceCal extracts event data from the page structure. This means:
-
-* The importer may require updates if TicketSource changes their website
-* If your events stop importing, please contact us so we can investigate

--- a/docs/reference/supported-calendar-sources/ticketsource.md
+++ b/docs/reference/supported-calendar-sources/ticketsource.md
@@ -1,0 +1,39 @@
+# TicketSource
+
+PlaceCal can import events from TicketSource venue pages. TicketSource is a UK-based ticketing platform used by many theatres, arts centres, and community venues.
+
+## How to import from TicketSource
+
+To import events from TicketSource, you need the URL of your **venue page** (not individual event pages). This is typically in the format:
+
+* `https://www.ticketsource.co.uk/your-venue-name`
+
+Simply paste this URL into the calendar field when [adding a calendar](../../how-to/add-a-calendar.md). PlaceCal will automatically detect it as a TicketSource source and import all upcoming events from that venue.
+
+## Information PlaceCal imports from TicketSource
+
+PlaceCal pulls the following from TicketSource events:
+
+* Event title
+* Description
+* Start date and time
+* End date and time
+* Location/venue address
+* Event URL
+
+## Important notes
+
+### Venue pages only
+
+PlaceCal imports from venue pages, not individual event pages. Make sure you use the main venue URL (e.g., `https://www.ticketsource.co.uk/fairfield-house`) rather than a specific event or ticket URL.
+
+### Multiple time slots
+
+If an event has multiple performances or time slots, PlaceCal will import each one as a separate event with its own date and time.
+
+### Fragile importer
+
+Like other web-scraping importers, TicketSource does not provide a public API or feed. PlaceCal extracts event data from the page structure. This means:
+
+* The importer may require updates if TicketSource changes their website
+* If your events stop importing, please contact us so we can investigate


### PR DESCRIPTION
Adds documentation for the new TicketSource calendar importer feature.

## Changes

- New page: `docs/reference/supported-calendar-sources/ticketsource.md`

## Contents

- How to import from TicketSource venue pages
- What information PlaceCal imports from TicketSource events
- Notes on using venue pages (not individual event pages)
- How multiple time slots are handled
- Fragile importer warning

## Related

- geeksforsocialchange/PlaceCal#2887 - TicketSource importer implementation