### PR TITLE
docs: Add Gold/Silver/Bronze integration tier system

### DIFF
--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -20,35 +20,23 @@ Bronze integrations scrape data from web pages without an official API or standa
 
 ## List of Supported Sources
 
-### 🥇 Gold - Stable
-
-| Source | Format | Notes |
-|--------|--------|-------|
-| [iCal/ICS (generic)](ical-generic.md) | iCal standard | Universal calendar format |
-| [JSON-LD (generic)](json-ld-generic.md) | JSON-LD standard | Structured data in web pages |
-| [Google Calendar](google-calendar.md) | iCal | Widely used, reliable |
-| [iCloud Calendar](icloud-calendar.md) | iCal | Apple calendar service |
-| [Outlook 365](outlook-365.md) | iCal | Microsoft calendar service |
-| [Airtable](airtable.md) | iCal | Database with calendar export |
-
-### 🥈 Silver - Semi-stable
-
-| Source | Format | Notes |
-|--------|--------|-------|
-| [Eventbrite](eventbrite.md) | JSON-LD | Popular ticketing platform |
-| [Meetup](meetup.md) | JSON-LD | Community events platform |
-| [Dice.fm](dice.fm.md) | JSON-LD | Music events platform |
-| [OutSavvy](outsavvy.md) | JSON-LD | Ticketing platform |
-| [Ticketsolve](ticketsolve.md) | JSON-LD | Legacy, limited testing |
-
-### 🥉 Bronze - Fragile
-
-| Source | Method | Notes |
-|--------|--------|-------|
-| [TicketSource](ticketsource.md) | Web scraping | UK ticketing platform |
-| [Squarespace](squarespace.md) | Web scraping | Website builder |
-| [Resident Advisor](resident-advisor-ra.md) | Web scraping | Music events platform |
-| [Wix](wix.md) | Web scraping | ⚠️ [BDS listed](https://boycottwix.org/) - see page for details |
+| Source | Tier | Format | Notes |
+|--------|------|--------|-------|
+| [Airtable](airtable.md) | 🥇 Gold | iCal | Database with calendar export |
+| [Dice.fm](dice.fm.md) | 🥈 Silver | JSON-LD | Music events platform |
+| [Eventbrite](eventbrite.md) | 🥈 Silver | JSON-LD | Popular ticketing platform |
+| [Google Calendar](google-calendar.md) | 🥇 Gold | iCal | Widely used, reliable |
+| [iCal/ICS (generic)](ical-generic.md) | 🥇 Gold | iCal | Universal calendar format |
+| [iCloud Calendar](icloud-calendar.md) | 🥇 Gold | iCal | Apple calendar service |
+| [JSON-LD (generic)](json-ld-generic.md) | 🥇 Gold | JSON-LD | Structured data in web pages |
+| [Meetup](meetup.md) | 🥈 Silver | JSON-LD | Community events platform |
+| [Outlook 365](outlook-365.md) | 🥇 Gold | iCal | Microsoft calendar service |
+| [OutSavvy](outsavvy.md) | 🥈 Silver | JSON-LD | Ticketing platform |
+| [Resident Advisor](resident-advisor-ra.md) | 🥉 Bronze | Web scraping | Music events platform |
+| [Squarespace](squarespace.md) | 🥉 Bronze | Web scraping | Website builder |
+| [TicketSource](ticketsource.md) | 🥉 Bronze | Web scraping | UK ticketing platform |
+| [Ticketsolve](ticketsolve.md) | 🥈 Silver | JSON-LD | Legacy, limited testing |
+| [Wix](wix.md) | 🥉 Bronze | Web scraping | ⚠️ [BDS listed](https://boycottwix.org/) |
 
 ---
 

--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -6,15 +6,15 @@ PlaceCal can import events from a variety of calendar and ticketing platforms. O
 
 ### 🥇 Gold - Stable
 
-Gold integrations use official APIs or standard formats (iCal, RSS, JSON-LD). These are the most reliable and unlikely to break.
+Gold integrations use official APIs or standard formats (iCal, JSON-LD). These are the most reliable and unlikely to break.
 
 ### 🥈 Silver - Semi-stable
 
-Silver integrations use structured data but may occasionally require maintenance. They have some official support or use stable data formats embedded in pages.
+Silver integrations use structured data from platforms that embed standard formats, but the way we access them may occasionally require maintenance.
 
 ### 🥉 Bronze - Fragile
 
-Bronze integrations scrape data from web pages without an official API or feed. These may break if the platform changes their website structure. We maintain these for community organisations who have limited ability to migrate platforms, but recommend Gold or Silver sources where possible.
+Bronze integrations scrape data from web pages without an official API or standard feed. These may break if the platform changes their website structure. We maintain these for community organisations who have limited ability to migrate platforms, but recommend Gold or Silver sources where possible.
 
 ---
 
@@ -25,6 +25,7 @@ Bronze integrations scrape data from web pages without an official API or feed. 
 | Source | Format | Notes |
 |--------|--------|-------|
 | [iCal/ICS (generic)](ical-generic.md) | iCal standard | Universal calendar format |
+| [JSON-LD (generic)](json-ld-generic.md) | JSON-LD standard | Structured data in web pages |
 | [Google Calendar](google-calendar.md) | iCal | Widely used, reliable |
 | [iCloud Calendar](icloud-calendar.md) | iCal | Apple calendar service |
 | [Outlook 365](outlook-365.md) | iCal | Microsoft calendar service |
@@ -34,7 +35,6 @@ Bronze integrations scrape data from web pages without an official API or feed. 
 
 | Source | Format | Notes |
 |--------|--------|-------|
-| [JSON-LD (generic)](json-ld-generic.md) | JSON-LD | Structured data in web pages |
 | [Eventbrite](eventbrite.md) | JSON-LD | Popular ticketing platform |
 | [Meetup](meetup.md) | JSON-LD | Community events platform |
 | [Dice.fm](dice.fm.md) | JSON-LD | Music events platform |

--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -1,37 +1,73 @@
-# Supported Calendar sources
+# Supported Calendar Sources
 
-By default PlaceCal supports [iCal/.ics](ical-generic.md) and [JSON-LD](json-ld-generic.md) data sources. PlaceCal also supports specific ticketing and event platforms which provide an API for integrations. These are listed below. Instructions for setting up a calendar feed which PlaceCal can import can be found by clicking through on the source you would like to use.&#x20;
+PlaceCal can import events from a variety of calendar and ticketing platforms. Our integrations are categorised into three tiers based on their stability and reliability.
 
-## List of supported sources
+## Integration Tiers
 
-* [Airtable](airtable.md)
-* [Dice.fm](dice.fm.md)
-* [Eventbrite](eventbrite.md)
-* [Google Calendar](google-calendar.md)
-* [iCloud Calendar](icloud-calendar.md)
-* [Meetup](meetup.md)
-* [Outlook 365](outlook-365.md)
-* [OutSavvy](outsavvy.md)
-* [Resident Advisor](resident-advisor-ra.md) (RA)
-* [Squarespace](squarespace.md)
-* [Ticketsolve](ticketsolve.md)
+### 🥇 Gold - Stable
 
-## Sources PlaceCal doesn't support
+Gold integrations use official APIs or standard formats (iCal, RSS, JSON-LD). These are the most reliable and unlikely to break.
+
+### 🥈 Silver - Semi-stable
+
+Silver integrations use structured data but may occasionally require maintenance. They have some official support or use stable data formats embedded in pages.
+
+### 🥉 Bronze - Fragile
+
+Bronze integrations scrape data from web pages without an official API or feed. These may break if the platform changes their website structure. We maintain these for community organisations who have limited ability to migrate platforms, but recommend Gold or Silver sources where possible.
+
+---
+
+## List of Supported Sources
+
+### 🥇 Gold - Stable
+
+| Source | Format | Notes |
+|--------|--------|-------|
+| [iCal/ICS (generic)](ical-generic.md) | iCal standard | Universal calendar format |
+| [Google Calendar](google-calendar.md) | iCal | Widely used, reliable |
+| [iCloud Calendar](icloud-calendar.md) | iCal | Apple calendar service |
+| [Outlook 365](outlook-365.md) | iCal | Microsoft calendar service |
+| [Airtable](airtable.md) | iCal | Database with calendar export |
+
+### 🥈 Silver - Semi-stable
+
+| Source | Format | Notes |
+|--------|--------|-------|
+| [JSON-LD (generic)](json-ld-generic.md) | JSON-LD | Structured data in web pages |
+| [Eventbrite](eventbrite.md) | JSON-LD | Popular ticketing platform |
+| [Meetup](meetup.md) | JSON-LD | Community events platform |
+| [Dice.fm](dice.fm.md) | JSON-LD | Music events platform |
+| [OutSavvy](outsavvy.md) | JSON-LD | Ticketing platform |
+| [Ticketsolve](ticketsolve.md) | JSON-LD | Legacy, limited testing |
+
+### 🥉 Bronze - Fragile
+
+| Source | Method | Notes |
+|--------|--------|-------|
+| [TicketSource](ticketsource.md) | Web scraping | UK ticketing platform |
+| [Squarespace](squarespace.md) | Web scraping | Website builder |
+| [Resident Advisor](resident-advisor-ra.md) | Web scraping | Music events platform |
+| [Wix](wix.md) | Web scraping | ⚠️ [BDS listed](https://boycottwix.org/) - see page for details |
+
+---
+
+## Sources PlaceCal Does Not Support
 
 ### Google Sheets
 
-We can’t meaningfully import [unstructured data](../../explanation/structured-and-unstructured-data.md). There are various Google Sheets to iCal integrations which you're welcome to try but we can’t offer specific support to these as they are constant moving targets.
+We cannot meaningfully import [unstructured data](../../explanation/structured-and-unstructured-data.md). There are various Google Sheets to iCal integrations which you are welcome to try but we cannot offer specific support as they are constantly changing.
 
 ### Facebook
 
-Facebook have closed their APIs and make it practically impossible to scrape public data. If you’re extremely brave you can try to improve our abandoned [faceloader Facebook scraping app](https://github.com/geeksforsocialchange/faceloader) but again, we can’t support with this.
+Facebook have closed their APIs and make it practically impossible to scrape public data. If you are extremely brave you can try to improve our abandoned [faceloader Facebook scraping app](https://github.com/geeksforsocialchange/faceloader) but again, we cannot support with this.
 
 ### Fatsoma
 
-Fatsoma don't provide a suitable API or metadata output.&#x20;
+Fatsoma do not provide a suitable API or metadata output.
 
-## Sources PlaceCal could support with additional resources&#x20;
+## Sources PlaceCal Could Support With Additional Resources
 
 ### TicketTailor
 
-TicketTailor have an API PlaceCal could use, with support to develop the importer.&#x20;
+TicketTailor have an API PlaceCal could use, with support to develop the importer.


### PR DESCRIPTION
## Summary

Introduces a tiered system for categorising calendar source integrations by stability and reliability. This helps users understand what to expect from each integration and choose appropriate sources.

## Integration Tiers

### 🥇 Gold - Stable
Uses official APIs or standard formats (iCal, RSS). Most reliable, unlikely to break.
- iCal generic, Google Calendar, iCloud Calendar, Outlook 365, Airtable

### 🥈 Silver - Semi-stable  
Uses structured data but may occasionally require maintenance.
- JSON-LD generic, Eventbrite, Meetup, Dice.fm, OutSavvy, Ticketsolve

### 🥉 Bronze - Fragile
Scrapes web pages without official API. May break if platforms change their sites.
- TicketSource, Squarespace, Resident Advisor, Wix

## Changes

- Rewrites `docs/reference/supported-calendar-sources/README.md` with:
  - Explanation of the three tiers
  - Table of all sources organised by tier
  - Notes on each source including format and any warnings

## Related PRs

This PR should be merged before or alongside:
- #2 (Wix documentation) - Bronze tier
- #3 (TicketSource documentation) - Bronze tier