### PR TITLE
Add WordPress (The Events Calendar) importer documentation

### DIFF
--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -14,8 +14,8 @@ By default PlaceCal supports [iCal/.ics](ical-generic.md) and [JSON-LD](json-ld-
 * [OutSavvy](outsavvy.md)
 * [Resident Advisor](resident-advisor-ra.md) (RA)
 * [Squarespace](squarespace.md)
-* [WordPress](wordpress.md) (The Events Calendar plugin)
 * [Ticketsolve](ticketsolve.md)
+* [WordPress](wordpress.md) (The Events Calendar plugin)
 
 ## Sources PlaceCal doesn't support
 

--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -14,6 +14,7 @@ By default PlaceCal supports [iCal/.ics](ical-generic.md) and [JSON-LD](json-ld-
 * [OutSavvy](outsavvy.md)
 * [Resident Advisor](resident-advisor-ra.md) (RA)
 * [Squarespace](squarespace.md)
+* [WordPress](wordpress.md) (The Events Calendar plugin)
 * [Ticketsolve](ticketsolve.md)
 
 ## Sources PlaceCal doesn't support

--- a/docs/reference/supported-calendar-sources/wordpress.md
+++ b/docs/reference/supported-calendar-sources/wordpress.md
@@ -1,8 +1,8 @@
 # WordPress
 
-There are many WordPress calendar plugins available. PlaceCal currently supports sites using [The Events Calendar](https://theeventscalendar.com/) plugin (also known as Tribe Events), which is one of the most popular options.
+There are many WordPress calendar plugins available. PlaceCal currently supports sites using [The Events Calendar](https://theeventscalendar.com/) plugin (also known as Tribe Events), which is one of the most popular options. This uses our [generic iCal importer](ical-generic.md).
 
-If you're using a different WordPress calendar plugin that provides an iCal feed, you may be able to use the [generic iCal importer](ical-generic.md) instead.
+Other WordPress calendar plugins that provide an iCal feed should also work with PlaceCal using the same method.
 
 ## The Events Calendar
 

--- a/docs/reference/supported-calendar-sources/wordpress.md
+++ b/docs/reference/supported-calendar-sources/wordpress.md
@@ -1,0 +1,41 @@
+# WordPress
+
+There are many WordPress calendar plugins available. PlaceCal currently supports sites using [The Events Calendar](https://theeventscalendar.com/) plugin (also known as Tribe Events), which is one of the most popular options.
+
+If you're using a different WordPress calendar plugin that provides an iCal feed, you may be able to use the [generic iCal importer](ical-generic.md) instead.
+
+## The Events Calendar
+
+To import events from a site using The Events Calendar, you need to find the iCal feed URL. Most sites expose this by adding `?ical=1` to the events page URL.
+
+For example, if the events page is:
+
+```
+https://example.org/events/
+```
+
+The iCal feed URL would be:
+
+```
+https://example.org/events/?ical=1
+```
+
+Paste this URL into the calendar field when [adding a calendar](../../how-to/add-a-calendar.md) and you should be good to go!
+
+### Finding the iCal feed
+
+1. Navigate to the events listing page on the WordPress site
+2. Add `?ical=1` to the end of the URL
+3. If the feed works, your browser will either download a file or display calendar data
+4. Use this URL as your PlaceCal calendar source
+
+## Information PlaceCal imports from WordPress
+
+* Unique ID
+* Event title
+* Description
+* Start date and time
+* End date and time
+* Address
+* URL
+* Online address (if an online event)


### PR DESCRIPTION
Adds documentation for importing events from WordPress sites using The Events Calendar plugin.

## Changes
- New `wordpress.md` page documenting how to find and use the iCal feed URL (`?ical=1`)
- Updated README to include WordPress in the supported sources list

## Notes
- Framed as WordPress documentation with The Events Calendar as the currently supported plugin
- Points users to generic iCal importer for other WordPress calendar plugins
- Example: https://lgbt.foundation/events/?ical=1