### PR TITLE
Add Ticket Tailor to supported calendar sources

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -29,6 +29,7 @@
   * [OutSavvy](reference/supported-calendar-sources/outsavvy.md)
   * [Resident Advisor (RA)](reference/supported-calendar-sources/resident-advisor-ra.md)
   * [Squarespace](reference/supported-calendar-sources/squarespace.md)
+  * [Ticket Tailor](reference/supported-calendar-sources/ticket-tailor.md)
   * [Ticketsolve](reference/supported-calendar-sources/ticketsolve.md)
 * [Glossary](reference/glossary/README.md)
   * [Calendars](reference/glossary/calendars.md)

--- a/docs/reference/supported-calendar-sources/README.md
+++ b/docs/reference/supported-calendar-sources/README.md
@@ -14,6 +14,7 @@ By default PlaceCal supports [iCal/.ics](ical-generic.md) and [JSON-LD](json-ld-
 * [OutSavvy](outsavvy.md)
 * [Resident Advisor](resident-advisor-ra.md) (RA)
 * [Squarespace](squarespace.md)
+* [Ticket Tailor](ticket-tailor.md) (requires API key)
 * [Ticketsolve](ticketsolve.md)
 * [WordPress](wordpress.md) (The Events Calendar plugin)
 
@@ -30,9 +31,3 @@ Facebook have closed their APIs and make it practically impossible to scrape pub
 ### Fatsoma
 
 Fatsoma don't provide a suitable API or metadata output.&#x20;
-
-## Sources PlaceCal could support with additional resources&#x20;
-
-### TicketTailor
-
-TicketTailor have an API PlaceCal could use, with support to develop the importer.&#x20;

--- a/docs/reference/supported-calendar-sources/ticket-tailor.md
+++ b/docs/reference/supported-calendar-sources/ticket-tailor.md
@@ -1,0 +1,36 @@
+# Ticket Tailor
+
+PlaceCal can import events from a [Ticket Tailor](https://www.tickettailor.com/) box office page. Unlike most other importers, Ticket Tailor requires an API key to access your events.
+
+## Setup
+
+### 1. Get your API key
+
+1. Log in to your Ticket Tailor account
+2. Go to **Box Office > API Keys**
+3. Create a new API key (or use an existing one)
+4. Copy the key (it starts with `sk_`)
+
+### 2. Add the calendar in PlaceCal
+
+1. [Add a calendar](../../how-to/add-a-calendar.md) using your Ticket Tailor box office URL as the source, e.g. `https://www.tickettailor.com/events/yourorganisation`
+2. PlaceCal will detect it as a Ticket Tailor feed and ask for your API key
+3. Paste your API key into the field provided
+
+PlaceCal will then import your published events automatically.
+
+## Information PlaceCal imports from Ticket Tailor
+
+* Unique ID
+* Event title
+* Description
+* Start date and time
+* End date and time
+* Venue name and postcode
+* Event URL
+
+## Notes
+
+* Only **published** events are imported. Draft or archived events are skipped.
+* Your API key is stored securely and is only used to fetch your event listings.
+* If your API key expires or is revoked, you can update it on the calendar settings page in PlaceCal.

--- a/docs/reference/supported-calendar-sources/ticket-tailor.md
+++ b/docs/reference/supported-calendar-sources/ticket-tailor.md
@@ -8,7 +8,7 @@ PlaceCal can import events from a [Ticket Tailor](https://www.tickettailor.com/)
 
 1. Log in to your Ticket Tailor account
 2. Go to **Box Office > API Keys**
-3. Create a new API key (or use an existing one)
+3. Create a new API key with **read** permission on **Events** only
 4. Copy the key (it starts with `sk_`)
 
 ### 2. Add the calendar in PlaceCal


### PR DESCRIPTION
Adds documentation for the new Ticket Tailor importer.

## Changes

- **New page**: `ticket-tailor.md` with setup instructions covering API key generation and calendar setup in PlaceCal
- **README**: Moved Ticket Tailor from "could support with additional resources" to the supported sources list
- **SUMMARY.md**: Added navigation entry

Corresponds to PlaceCal PR [#2888](https://github.com/geeksforsocialchange/PlaceCal/pull/2888).